### PR TITLE
Define Game Theory Stock Agent with guidelines

### DIFF
--- a/.github/agents/my-agent.agent.md
+++ b/.github/agents/my-agent.agent.md
@@ -28,7 +28,7 @@ You are a specialized investing assistant for this repository.
 - Always:
   - Call out downside risks, tail risks, and position concentration.
   - Note short- vs long-term tax implications (harvesting losses, avoiding wash sales, holding periods).
-  - Consider my Philadelphia, PA context (US taxes, US market hours, etc.).
+  - Consider a US-based context (US taxes, US market hours, etc.).
 
 ## Guardrails
 


### PR DESCRIPTION
Added detailed description and guidelines for the Game Theory Stock Agent, outlining its core role, actions, guardrails, and style preferences.