### PR TITLE
⚡ Bolt: Cache stock info requests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-23 - Batch Data Fetching
 **Learning:** `yfinance` allows batch fetching via `download(tickers_list)`. This reduces N+1 HTTP requests to 1 request.
 **Action:** Prefer `fetch_batch_data` pattern for pre-loading data when the set of keys (tickers) is known in advance (e.g., in a loop).
+
+## 2024-05-24 - Missing Info Caching
+**Learning:** `StockDataFetcher.get_stock_info` was fetching metadata individually for every ticker without caching, causing significant latency during portfolio analysis re-runs.
+**Action:** Implemented `info_cache` to store and reuse stock metadata, reducing network calls for static data.


### PR DESCRIPTION
*   💡 What: Implemented in-memory caching for `get_stock_info` calls in `StockDataFetcher`.
*   🎯 Why: The application was making redundant network requests for static stock metadata (name, sector, etc.) every time the portfolio was analyzed or the app re-ran, causing unnecessary latency.
*   📊 Impact: Reduces network calls for stock metadata to exactly one per ticker per session.
*   🔬 Measurement: Added `test_get_stock_info_uses_cache` which verifies that `yfinance.Ticker` is only called once for repeated requests.

---
*PR created automatically by Jules for task [9830750456092720960](https://jules.google.com/task/9830750456092720960) started by @QTechDevelopment*